### PR TITLE
Enhance SEO metadata and add sitemap

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,20 +1,120 @@
+const siteUrl = "https://lukabartulovic.com";
+
 export const metadata = {
-  title: "Luka Bartulović",
-  description: "Turning Ideas into Scalable, Beautiful Apps",
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: "Luka Bartulović | Frontend Developer in Croatia",
+    template: "%s | Luka Bartulović — Frontend Developer in Croatia",
+  },
+  description:
+    "Luka Bartulović is a Croatia-based front-end engineer building fast, scalable web and mobile products for startups and ambitious teams.",
+  keywords: [
+    "Luka Bartulović",
+    "Luka Bartulovic",
+    "frontend developer Croatia",
+    "front end hrvatska",
+    "React consultant",
+    "Next.js expert",
+    "Croatia UI engineer",
+  ],
+  authors: [{ name: "Luka Bartulović", url: siteUrl }],
+  alternates: {
+    canonical: siteUrl,
+    languages: {
+      en: siteUrl,
+      hr: `${siteUrl}/?lang=hr`,
+    },
+  },
+  openGraph: {
+    type: "profile",
+    locale: "en_US",
+    url: siteUrl,
+    title: "Luka Bartulović | Frontend Developer in Croatia",
+    description:
+      "Freelance front-end developer from Split, Croatia creating high-performing digital experiences with React and Next.js.",
+    siteName: "Luka Bartulović Portfolio",
+    images: [
+      {
+        url: `${siteUrl}/api/og`,
+        width: 1200,
+        height: 630,
+        alt: "Luka Bartulović — Croatia Frontend Developer",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@lukabartulovic",
+    title: "Luka Bartulović | Frontend Developer in Croatia",
+    description:
+      "Front-end engineer in Croatia delivering fast, modern interfaces with React, Next.js and strong SEO foundations.",
+    images: [`${siteUrl}/api/og`],
+  },
+  category: "technology",
+  robots: {
+    index: true,
+    follow: true,
+  },
   verification: {
     google: "VLQOF6AG39HHR2ijeTNw8WDuIOgmTsHoAj-9MIsvBKw",
   },
 };
 
 import { Analytics } from "@vercel/analytics/next";
+import Script from "next/script";
 
 import "./globals.css";
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Luka Bartulović",
+  alternateName: ["Luka Bartulovic", "Luka Bartulović frontend"],
+  url: siteUrl,
+  jobTitle: "Frontend Developer",
+  description:
+    "Frontend developer based in Split, Croatia delivering high-performance web apps, SEO-friendly experiences, and mobile interfaces.",
+  address: {
+    "@type": "PostalAddress",
+    addressLocality: "Split",
+    addressCountry: "Croatia",
+  },
+  sameAs: [
+    "https://www.linkedin.com/in/luka-bartulović-5b562b200/",
+    "https://github.com/bartul9",
+    "mailto:bartul123@outlook.com",
+  ],
+  knowsAbout: [
+    "React",
+    "Next.js",
+    "Frontend development",
+    "SEO",
+    "Product design",
+  ],
+  knowsLanguage: ["Croatian", "English"],
+  alumniOf: {
+    "@type": "CollegeOrUniversity",
+    name: "University of Split",
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Split",
+      addressCountry: "Croatia",
+    },
+  },
+};
 
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <Analytics />
-      <body className="bg-black relative">{children}</body>
+      <head>
+        <Script id="ld-json" type="application/ld+json" strategy="beforeInteractive">
+          {JSON.stringify(structuredData)}
+        </Script>
+      </head>
+      <body className="bg-black relative">
+        <Analytics />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/manifest.json
+++ b/src/app/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "LB",
-  "short_name": "LB",
+  "name": "Luka Bartulović Portfolio",
+  "short_name": "Luka Bartulović",
+  "description": "Portfolio of Luka Bartulović, a Croatia-based frontend developer and product builder.",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { Github, Linkedin, Mail } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import MatrixRain from "@/components/MatrixRain";
 import SectionTitle from "@/components/SectionTitle";
@@ -21,9 +21,13 @@ function onSheenMove(e) {
 /* -------- scroll spy (center-of-viewport) -------- */
 function useScrollSpy(selectors = [], { offset = "header" } = {}) {
   const [active, setActive] = useState(null);
+  const selectorList = useMemo(
+    () => (Array.isArray(selectors) ? selectors : [selectors]),
+    [selectors]
+  );
 
   useEffect(() => {
-    const sections = selectors
+    const sections = selectorList
       .map((s) => document.querySelector(s))
       .filter(Boolean);
 
@@ -71,7 +75,7 @@ function useScrollSpy(selectors = [], { offset = "header" } = {}) {
       window.removeEventListener("scroll", onScroll);
       window.removeEventListener("resize", onScroll);
     };
-  }, [JSON.stringify(selectors), offset]);
+  }, [selectorList, offset]);
 
   return active;
 }
@@ -338,9 +342,10 @@ export default function Home() {
               viewport={{ once: true }}
               className="mt-3 text-[clamp(1rem,3.2vw,1.35rem)] text-[--color-neon-200] max-w-[80ch]"
             >
-              Turning Ideas into{" "}
-              <span className="text-[--color-neon-500]">Scalable</span>,
-              Beautiful Apps
+              Croatia-based front-end engineer building{" "}
+              <span className="text-[--color-neon-500]">scalable</span>,
+              beautiful digital products for startups, founders, and tech
+              teams across Europe.
             </motion.p>
 
             <motion.div
@@ -350,6 +355,10 @@ export default function Home() {
             >
               <TypeMotto />
             </motion.div>
+
+            <p className="mt-6 text-sm uppercase tracking-[0.2em] text-white/60">
+              Luka Bartulović • Luka Bartulovic • Frontend developer Hrvatska
+            </p>
           </div>
 
           <a
@@ -382,15 +391,18 @@ export default function Home() {
 
             <div className="mt-6 md:mt-8 grid md:grid-cols-2 gap-6 md:gap-8">
               <p className="text-base md:text-lg leading-relaxed text-gray-200 p-2">
-                I’m Luka — a frontend engineer and product builder. I create{" "}
-                <b>fast</b>, <b>beautifully designed</b> web and mobile apps.
-                Clean UIs, subtle but powerful animation, and crystal-clear UX.
-                I’m also interested in the <b>backend</b> side — Node.js,
+                I’m Luka Bartulović (often typed as Luka Bartulovic) — a
+                frontend engineer and product builder based in Split,
+                Hrvatska. I create <b>fast</b>, <b>beautifully designed</b> web
+                and mobile apps that rank, convert, and delight. Clean UIs,
+                subtle but powerful animation, and crystal-clear UX. I’m also
+                interested in the <b>backend</b> side — Node.js,
                 Supabase/Postgres, Prisma, webhooks and Edge functions — so I
                 can own the full vertical slice. My mindset is
                 <b> Maximum Game</b>: focus, speed, problem-solving and
                 delivery. Currently pushing <i>PartyGate</i>,{" "}
-                <i>Tarot/Natal AI</i> and client work (SEO, sales, booking).
+                <i>Tarot/Natal AI</i> and client work (SEO, sales, booking) for
+                partners across Croatia and the EU.
               </p>
 
               <ul className="grid gap-3">
@@ -526,6 +538,38 @@ export default function Home() {
         </div>
       </section>
 
+      {/* FAQ / SEO */}
+      <section
+        id="faq"
+        aria-labelledby="faq-heading"
+        className="relative z-10 py-16 md:py-24"
+      >
+        <div className="container">
+          <SectionTitle id="faq-heading">Frequently Asked Questions</SectionTitle>
+          <dl className="mt-8 grid grid-cols-1 lg:grid-cols-3 gap-4">
+            {[
+              {
+                q: "Who is Luka Bartulović?",
+                a: "Luka Bartulović (also written Luka Bartulovic) is a Croatia-based front-end developer building high-performing user interfaces with React, Next.js, and product strategy experience.",
+              },
+              {
+                q: "Where does Luka work from?",
+                a: "I live in Split, Hrvatska and partner with clients throughout Croatia and the EU, offering remote-first collaboration with on-site availability when projects need it.",
+              },
+              {
+                q: "Do you offer front end development in Hrvatska?",
+                a: "Yes. I help Croatian startups, agencies, and founders with end-to-end front-end development, performance tuning, SEO, and UI polish so their products stand out in search and in the market.",
+              },
+            ].map(({ q, a }) => (
+              <div key={q} className="card p-5 text-left">
+                <dt className="text-lg font-semibold text-white">{q}</dt>
+                <dd className="mt-2 text-sm opacity-85 leading-relaxed">{a}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+
       {/* CONTACT */}
       <section id="contact" className="relative z-10 py-20 md:py-28">
         <div className="container text-center">
@@ -534,8 +578,13 @@ export default function Home() {
           </h2>
 
           <p className="mt-4 opacity-90">
-            Open to frontend / React / RN roles and ambitious AI products.
+            Open to frontend / React / RN roles and ambitious AI products
+            across Croatia, the Balkans, and worldwide.
           </p>
+
+          <address className="mt-2 text-xs uppercase tracking-[0.3em] text-white/50 not-italic">
+            Split • Dalmatia • Croatia / Hrvatska
+          </address>
 
           <div
             className="cta-wrap mx-auto mt-8 w-fit  max-w-3xl"

--- a/src/app/robots.js
+++ b/src/app/robots.js
@@ -1,0 +1,11 @@
+const siteUrl = "https://lukabartulovic.com";
+
+export default function robots() {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -1,0 +1,14 @@
+const siteUrl = "https://lukabartulovic.com";
+
+export default function sitemap() {
+  const lastModified = new Date();
+
+  return [
+    {
+      url: siteUrl,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ];
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+const config = {
   content: ["./src/**/*.{js,jsx,ts,tsx,mdx}", "./app/**/*.{js,jsx,ts,tsx,mdx}"],
   theme: {
     extend: {
@@ -18,3 +18,5 @@ export default {
   },
   plugins: [],
 };
+
+export default config;


### PR DESCRIPTION
## Summary
- enrich global metadata with detailed SEO targets, Open Graph/Twitter cards, and structured data for Luka Bartulović
- expand homepage copy with Croatia-focused keywords, FAQ content, and updated contact details to capture relevant search queries
- add sitemap and robots routes plus update manifest branding for search friendliness

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2e565e598832188d4f89178dbabad